### PR TITLE
Add compatibility for Zsh

### DIFF
--- a/postexec_notify
+++ b/postexec_notify
@@ -12,9 +12,10 @@
 # ----------------------------------------------------------------------------------
 # Get working directory. It is directory where this script is located
 # http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+# https://stackoverflow.com/a/54755784/9157799
 # Is a useful one-liner which will give you the full directory name
 # of the script no matter where it is being called from
-WORKING_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+WORKING_DIR="$(dirname ${BASH_SOURCE[0]:-${(%):-%x}})"
 
 # Treshold from which we start to notify about long running commands
 # this is define what is "long-running"


### PR DESCRIPTION
[The code](https://github.com/c0rp-aubakirov/notify_after_command_executed/blob/911b19043e8c2537e45a559bab2d7d502c485813/postexec_notify#L17) to get `WORKING_DIR` doesn't work in Zsh. Instead of giving the script location, it gives the current shell location. This cause issues such as:

1. [play_sound file not found](https://github.com/c0rp-aubakirov/notify_after_command_executed/blob/911b19043e8c2537e45a559bab2d7d502c485813/postexec_notify#L47) as in #3.
2. postexec_notify [always downloading preexec.sh](https://github.com/c0rp-aubakirov/notify_after_command_executed/blob/911b19043e8c2537e45a559bab2d7d502c485813/postexec_notify#L26) to directories where I open a new terminal tab from that directory.